### PR TITLE
Fixed MusicClient.Get() when LookupOptions not null

### DIFF
--- a/src/Xbox.Music.Tests/MusicClientTests.cs
+++ b/src/Xbox.Music.Tests/MusicClientTests.cs
@@ -14,7 +14,7 @@ namespace Xbox.Music.Tests
     {
 
         private static string _find1ContinuationToken = "";
-        private static string _get1ContinuationToken = "";
+        //private static string _get1ContinuationToken = "";
 
         [TestMethod]
         public async Task FindTest1()
@@ -83,6 +83,16 @@ namespace Xbox.Music.Tests
             Assert.IsNotNull(result.Artists);
             //Assert.IsNotNull(result.Tracks);
             //Assert.IsNotNull(result.Albums);
+        }
+
+        [TestMethod]
+        public async Task GetArtistDetails()
+        {
+            var client = new MusicClient("XboxMusicClientTests", "ThisWillBeChangedOften");
+            var result = await client.Get("music.C61C0000-0200-11DB-89CA-0019B92A3933", new LookupOptions(true));
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.Error);
+            Assert.IsNotNull(result.Artists);
         }
 
         [TestMethod]

--- a/src/Xbox.Music.Tests/Xbox.Music.Tests.csproj
+++ b/src/Xbox.Music.Tests/Xbox.Music.Tests.csproj
@@ -38,15 +38,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Xbox.Music.Tests/Xbox.Music.Tests.csproj
+++ b/src/Xbox.Music.Tests/Xbox.Music.Tests.csproj
@@ -49,23 +49,23 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PortableRest, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\PortableRest.3.0.0-RC7\lib\portable-net45+sl5+wp8+win8+wpa81\PortableRest.dll</HintPath>
+      <HintPath>..\packages\PortableRest.3.0.1\lib\portable-net45+sl5+wp8+win8+wpa81+MonoTouch1+MonoAndroid1\PortableRest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.27-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.27-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
@@ -120,6 +120,11 @@
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Xbox.Music.Tests/app.config
+++ b/src/Xbox.Music.Tests/app.config
@@ -4,7 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.27.0" newVersion="4.2.27.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.22.0" newVersion="4.2.22.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Xbox.Music.Tests/packages.config
+++ b/src/Xbox.Music.Tests/packages.config
@@ -3,7 +3,10 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net451" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net451" />
   <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="net451" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net451" />
   <package id="Microsoft.Net.Http" version="2.2.27-beta" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net451" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
   <package id="PortableRest" version="3.0.0-RC7" targetFramework="net451" />
+  <package id="PortableRest" version="3.0.1" targetFramework="net451" />
 </packages>

--- a/src/Xbox.Music.Tests/packages.config
+++ b/src/Xbox.Music.Tests/packages.config
@@ -3,10 +3,7 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net451" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net451" />
   <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="net451" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net451" />
-  <package id="Microsoft.Net.Http" version="2.2.27-beta" targetFramework="net451" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
-  <package id="PortableRest" version="3.0.0-RC7" targetFramework="net451" />
   <package id="PortableRest" version="3.0.1" targetFramework="net451" />
 </packages>

--- a/src/Xbox.Music/Models/Artist.cs
+++ b/src/Xbox.Music/Models/Artist.cs
@@ -46,7 +46,7 @@ namespace Xbox.Music
         /// a few fields, including the ID that should be used in a lookup request in order to have the full album properties.
         /// </remarks>
         [DataMember]
-        public List<Album> Albums { get; set; }
+        public PaginatedList<Album> Albums { get; set; }
 
         /// <summary>
         /// A paginated list of the artist's top tracks, ordered by decreasing order of popularity. 
@@ -56,7 +56,7 @@ namespace Xbox.Music
         /// only a few fields, including the ID that should be used in a lookup request in order to have the full track properties.
         /// </remarks>
         [DataMember]
-        public List<Track> TopTracks { get; set; }
+        public PaginatedList<Track> TopTracks { get; set; }
 
         #endregion
 

--- a/src/Xbox.Music/Models/Error.cs
+++ b/src/Xbox.Music/Models/Error.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Runtime.Serialization;
 
 namespace Xbox.Music
@@ -38,6 +39,12 @@ namespace Xbox.Music
         /// </summary>
         [DataMember]
         public HttpResponseMessage Response { get; set; }
+
+        /// <summary>
+        /// Exception that has been thrown
+        /// </summary>
+        [DataMember]
+        public Exception Exception { get; set; }
 
     }
 }

--- a/src/Xbox.Music/MusicClient.cs
+++ b/src/Xbox.Music/MusicClient.cs
@@ -284,7 +284,7 @@ namespace Xbox.Music
             var request = new RestRequest("v2/OAuth2-13", HttpMethod.Post)
             {
                 ContentType = ContentTypes.FormUrlEncoded,
-                ReturnRawString = true,
+                //ReturnRawString = true,
             };
             request.AddParameter("client_id", ClientId);
             request.AddParameter("client_secret", ClientSecret);
@@ -348,7 +348,7 @@ namespace Xbox.Music
                 Error = new Error
                 {
                     ErrorCode = result.HttpResponseMessage != null ? result.HttpResponseMessage.StatusCode.ToString() : "",
-                    Message = result.HttpResponseMessage != null ? result.HttpResponseMessage.ReasonPhrase : result.SerializationException.Message,
+                    Message = result.HttpResponseMessage != null ? result.HttpResponseMessage.ReasonPhrase : result.Exception.Message,
                     Response = result.HttpResponseMessage,
                 }
             };

--- a/src/Xbox.Music/MusicClient.cs
+++ b/src/Xbox.Music/MusicClient.cs
@@ -41,7 +41,7 @@ namespace Xbox.Music
         /// Responses will be filtered to provide only those that match the user's country/region.
         /// </summary>
         public string Country { get; set; }
-        
+
         /// <summary>
         /// Required. A valid developer authentication Access Token obtained from Azure Data Market, 
         /// used to identify the third-party application using the Xbox Music RESTful API.
@@ -163,7 +163,7 @@ namespace Xbox.Music
             if (string.IsNullOrWhiteSpace(id))
                 throw new ArgumentNullException("id", "You must specify an ID");
 
-            return await Get(new List<string> {id}, options);
+            return await Get(new List<string> { id }, options);
         }
 
         /// <summary>
@@ -343,13 +343,20 @@ namespace Xbox.Music
                 return result.Content;
             }
 
+            string errorMessage = null;
+            if (result.HttpResponseMessage != null)
+                errorMessage += string.Format("HttpResponseMessage: {0}\n", result.HttpResponseMessage.ReasonPhrase);
+            if (result.Exception != null)
+                errorMessage += string.Format("Exception: {0}", result.Exception.Message);
+
             return new ContentResponse
             {
                 Error = new Error
                 {
                     ErrorCode = result.HttpResponseMessage != null ? result.HttpResponseMessage.StatusCode.ToString() : "",
-                    Message = result.HttpResponseMessage != null ? result.HttpResponseMessage.ReasonPhrase : result.Exception.Message,
+                    Message = errorMessage,
                     Response = result.HttpResponseMessage,
+                    Exception = result.Exception
                 }
             };
 
@@ -379,7 +386,7 @@ namespace Xbox.Music
             {
                 request.AddQueryString("country", Country);
             }
-           
+
             return request;
         }
 

--- a/src/Xbox.Music/Xbox.Music.csproj
+++ b/src/Xbox.Music/Xbox.Music.csproj
@@ -64,20 +64,25 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="PortableRest">
-      <HintPath>..\packages\PortableRest.3.0.0-RC7\lib\portable-net45+sl5+wp8+win8+wpa81\PortableRest.dll</HintPath>
+    <Reference Include="PortableRest, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PortableRest.3.0.1\lib\portable-net45+sl5+wp8+win8+wpa81+MonoTouch1+MonoAndroid1\PortableRest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.27-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.27-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.27-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -89,6 +94,11 @@
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Xbox.Music/Xbox.Music.csproj
+++ b/src/Xbox.Music/Xbox.Music.csproj
@@ -58,11 +58,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Threading.Tasks">
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/src/Xbox.Music/packages.config
+++ b/src/Xbox.Music/packages.config
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wp80" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+win+wp80" />
-  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="portable-net45+win+wp80" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wp80" />
-  <package id="Microsoft.Net.Http" version="2.2.27-beta" targetFramework="portable-net45+win+wp80" />
-  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wp80" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wp80" />
-  <package id="PortableRest" version="3.0.0-RC7" targetFramework="portable-net45+win+wp80" />
-  <package id="PortableRest" version="3.0.1" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="portable-net45+win8+wp8" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win8+wp8" />
+  <package id="PortableRest" version="3.0.1" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/src/Xbox.Music/packages.config
+++ b/src/Xbox.Music/packages.config
@@ -3,7 +3,10 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wp80" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable-net45+win+wp80" />
   <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.27-beta" targetFramework="portable-net45+win+wp80" />
-  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wp80" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wp80" />
   <package id="PortableRest" version="3.0.0-RC7" targetFramework="portable-net45+win+wp80" />
+  <package id="PortableRest" version="3.0.1" targetFramework="portable-net45+win+wp80" />
 </packages>


### PR DESCRIPTION
MusicClient.Get() was returning an error when LookupOptions was not null.
It has been fixed by changing the "Albums" and "TopTracks" properties of the Artist class from Lists to PaginatedLists.
I have also added an "Exception" property in the Error class so it's easier to find what went wrong.
